### PR TITLE
refactor: Use awalterschulze/gographviz

### DIFF
--- a/cmd/transition.go
+++ b/cmd/transition.go
@@ -107,13 +107,16 @@ func createDot(cmd *cobra.Command, result *stool.Transition, format string, fs a
 			if count == 0 {
 				continue
 			}
-			graph.AddEdge(source, target, true, nil)
+			err := graph.AddEdge(source, target, true, nil)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
-	if format == string("dot") {
+	if format == "dot" {
 		fmt.Fprintln(cmd.OutOrStdout(), graph.String())
-	} else if format == string("png") {
+	} else if format == "png" {
 	} else {
 		return fmt.Errorf("invalid format: %s", format)
 	}

--- a/cmd/transition.go
+++ b/cmd/transition.go
@@ -30,7 +30,7 @@ func NewTransitionCmd(p *stool.TransitionProfiler, v *viper.Viper, fs afero.Fs) 
 	transitionCmd.PersistentFlags().StringSliceP("matching_groups", "m", []string{}, "comma-separated list of regular expression patterns to group matched URIs")
 	transitionCmd.PersistentFlags().StringSlice("ignore_patterns", []string{}, "comma-separated list of regular expression patterns to ignore URIs")
 	transitionCmd.PersistentFlags().String("time_format", "02/Jan/2006:15:04:05 -0700", "format to parse time field on log file")
-	transitionCmd.PersistentFlags().String("format", "dot", "The output format (dot, png, csv)")
+	transitionCmd.PersistentFlags().String("format", "dot", "The output format (dot, csv)")
 	_ = v.BindPFlags(transitionCmd.PersistentFlags())
 	v.SetFs(fs)
 
@@ -64,16 +64,14 @@ func runTransition(cmd *cobra.Command, p *stool.TransitionProfiler, v *viper.Vip
 	format := v.GetString("format")
 	switch strings.ToLower(format) {
 	case "dot":
-		return createDot(cmd, result, "dot", fs)
-	case "png":
-		return createDot(cmd, result, "png", fs)
+		return createDot(cmd, result, fs)
 	case "csv":
 		return printTransitionCsv(cmd, result)
 	}
 	return fmt.Errorf("invalid format flag: %s", format)
 }
 
-func createDot(cmd *cobra.Command, result *stool.Transition, format string, fs afero.Fs) error {
+func createDot(cmd *cobra.Command, result *stool.Transition, fs afero.Fs) error {
 	graph := gographviz.NewEscape()
 	if err := graph.SetName("stool transition"); err != nil {
 		return err
@@ -114,12 +112,7 @@ func createDot(cmd *cobra.Command, result *stool.Transition, format string, fs a
 		}
 	}
 
-	if format == "dot" {
-		fmt.Fprintln(cmd.OutOrStdout(), graph.String())
-	} else if format == "png" {
-	} else {
-		return fmt.Errorf("invalid format: %s", format)
-	}
+	fmt.Fprintln(cmd.OutOrStdout(), graph.String())
 	return nil
 }
 

--- a/cmd/transition.go
+++ b/cmd/transition.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/csv"
 	"fmt"
 	"math"
@@ -9,8 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/goccy/go-graphviz"
-	"github.com/goccy/go-graphviz/cgraph"
+	"github.com/awalterschulze/gographviz"
 	"github.com/haijima/stool"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -76,66 +74,24 @@ func runTransition(cmd *cobra.Command, p *stool.TransitionProfiler, v *viper.Vip
 }
 
 func createDot(cmd *cobra.Command, result *stool.Transition, format string, fs afero.Fs) error {
-	g := graphviz.New()
-	graph, err := g.Graph()
-	if err != nil {
+	graph := gographviz.NewEscape()
+	if err := graph.SetName("stool transition"); err != nil {
 		return err
 	}
-	defer func() {
-		if err := graph.Close(); err != nil {
-			cobra.CheckErr(err)
-		}
-		g.Close()
-	}()
-	graph.SetStart(cgraph.RegularStart)
-	graph.SetESep(1)
+	if err := graph.SetDir(true); err != nil {
+		return err
+	}
 
 	eps := result.Endpoints.ToSlice()
 	sort.Strings(eps)
-	maxSum := 2 // if maxSum <= 1 error will occur on logNorm()
-	for _, e := range eps {
-		s := result.Sum[e]
-		if s > maxSum {
-			maxSum = s
-		}
-	}
 
-	nodes := map[string]*cgraph.Node{}
 	for _, e := range eps {
 		if e == "" {
 			continue
 		}
-		n, err := graph.CreateNode(e)
+		err := graph.AddNode("G", e, nil)
 		if err != nil {
 			return err
-		}
-		nodes[e] = n
-		n.SetLabel(fmt.Sprintf("%s\n(Call: %d)", e, result.Sum[e]))
-
-		n.SetShape(cgraph.BoxShape)
-		n.SetMargin(0.2)
-		fontSize, err := logNorm(result.Sum[e], maxSum, 34)
-		if err != nil {
-			return err
-		}
-		n.SetFontSize(fontSize + 8)                     // [8, 42]
-		level, err := logNorm(result.Sum[e], maxSum, 5) // level: [0, 5]
-		if err != nil {
-			return err
-		}
-		n.SetPenWidth(level + 1)
-		n.SafeSet("style", "solid,filled", "")
-
-		n.SetColorScheme("reds6")
-		if level >= 3 { // [3, 5]
-			n.SetColor(strconv.Itoa(int(math.Round(level) + 1)))
-		} else if level >= 2 { // [2, 3)
-			n.SetColor("#2f4f4f")
-		} else { // [0, 2)
-			n.SetColor("#696969")
-		}
-		if level >= 3 {
-			n.SetFillColor(strconv.Itoa(int(math.Round(level))))
 		}
 	}
 
@@ -151,43 +107,16 @@ func createDot(cmd *cobra.Command, result *stool.Transition, format string, fs a
 			if count == 0 {
 				continue
 			}
-			e, err := graph.CreateEdge(strconv.Itoa(count), nodes[source], nodes[target])
-			if err != nil {
-				return err
-			}
-			level, err := logNorm(count, maxSum, 5) // level: [0, 5]
-			if err != nil {
-				return err
-			}
-			e.SetLen(1 / (1 + level))
-			e.SetPenWidth(level + 1)
-			e.SetColorScheme("reds6")
-			if level >= 3 {
-				e.SetColor(strconv.Itoa(int(math.Round(level) + 1)))
-			} else if level == 2 {
-				e.SetColor("#2f4f4f")
-			} else {
-				e.SetColor("#696969")
-			}
+			graph.AddEdge(source, target, true, nil)
 		}
 	}
 
-	var filename string
-	if format == string(graphviz.XDOT) {
-		filename = "./graph.dot"
-	} else if format == string(graphviz.PNG) {
-		filename = "./graph.png"
+	if format == string("dot") {
+		fmt.Fprintln(cmd.OutOrStdout(), graph.String())
+	} else if format == string("png") {
 	} else {
 		return fmt.Errorf("invalid format: %s", format)
 	}
-	var buf bytes.Buffer
-	if err := g.Render(graph, graphviz.Format(format), &buf); err != nil {
-		return err
-	}
-	if err := afero.WriteFile(fs, filename, buf.Bytes(), 0644); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/cmd/transition_test.go
+++ b/cmd/transition_test.go
@@ -63,7 +63,7 @@ func Test_TransitionCmd_RunE(t *testing.T) {
 	err := cmd.RunE(cmd, []string{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, "", stdout.String())
+	assert.Equal(t, "digraph \"stool transition\" {\n\t\"POST /initialize\"->\"GET /\";\n\t\"GET /\";\n\t\"POST /initialize\";\n\n}\n\n", stdout.String())
 }
 
 func Test_TransitionCmd_RunE_file_not_exists(t *testing.T) {
@@ -78,27 +78,6 @@ func Test_TransitionCmd_RunE_file_not_exists(t *testing.T) {
 	err := cmd.RunE(cmd, []string{})
 
 	assert.ErrorContains(t, err, "not_exists.log")
-}
-
-func Test_TransitionCmd_RunE_format_png(t *testing.T) {
-	p := stool.NewTransitionProfiler()
-	v := viper.New()
-	fs := afero.NewMemMapFs()
-	cmd := NewTransitionCmd(p, v, fs)
-
-	fileName := "./access.log"
-	v.Set("file", fileName)
-	v.Set("format", "png")
-	_, _ = fs.Create(fileName)
-	_ = afero.WriteFile(fs, fileName, []byte("time:20/Jan/2023:14:39:01 +0900\thost:192.168.0.10\tforwardedfor:-\treq:POST /initialize HTTP/2.0\tstatus:200\tmethod:POST\turi:/initialize\tsize:18\treferer:-\tua:benchmarker-initializer\treqtime:0.268\tcache:-\truntime:-\tapptime:0.268\tvhost:192.168.0.11\tuidset:uid=0B00A8C0F528CA635B26685F02030303\tuidgot:-\tcookie:-\ntime:20/Jan/2023:14:39:06 +0900\thost:192.168.0.10\tforwardedfor:-\treq:GET / HTTP/2.0\tstatus:200\tmethod:GET\turi:/\tsize:528\treferer:-\tua:Mozilla/5.0 (X11; U; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36 Edg/85.0.564.44\treqtime:0.002\tcache:-\truntime:-\tapptime:0.000\tvhost:192.168.0.11\tuidset:uid=0B00A8C0FA28CA635B26685F02040303\tuidgot:-\tcookie:-"), 0777)
-
-	stdout := new(bytes.Buffer)
-	cmd.SetOut(stdout)
-
-	err := cmd.RunE(cmd, []string{})
-
-	assert.NoError(t, err)
-	assert.Equal(t, "", stdout.String())
 }
 
 func Test_TransitionCmd_RunE_format_csv(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Wing924/ltsv v0.3.1
+	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/deckarep/golang-set/v2 v2.1.0
-	github.com/goccy/go-graphviz v0.1.0
 	github.com/samber/lo v1.37.0
 	github.com/spf13/afero v1.9.3
 	github.com/spf13/cobra v1.6.1
@@ -16,15 +16,12 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fogleman/gg v1.3.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
@@ -33,7 +30,6 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
-	golang.org/x/image v0.0.0-20200119044424-58c23975cae1 // indirect
 	golang.org/x/sys v0.3.0 // indirect
 	golang.org/x/text v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Wing924/ltsv v0.3.1 h1:hbjzQ6YuS/sOm7nQJG7ddT9ua1yYmcH25Q8lsuiQE0A=
 github.com/Wing924/ltsv v0.3.1/go.mod h1:zl47wq7H23LocdDHg7yJAH/Qdc4MWHXu1Evx9Ahilmo=
+github.com/awalterschulze/gographviz v2.0.3+incompatible h1:9sVEXJBJLwGX7EQVhLm2elIKCm7P2YHFC8v6096G09E=
+github.com/awalterschulze/gographviz v2.0.3+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -50,8 +52,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/corona10/goimagehash v1.0.2 h1:pUfB0LnsJASMPGEZLj7tGY251vF+qLGqOgEP4rUs6kA=
-github.com/corona10/goimagehash v1.0.2/go.mod h1:/l9umBhvcHQXVtQO1V6Gp1yD20STawkhRnnX0D1bvVI=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -64,18 +64,12 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
-github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/goccy/go-graphviz v0.1.0 h1:6OqQoQ5PeAiHYe/YcusyeulqBrOkUb16HQ4ctRdyVUU=
-github.com/goccy/go-graphviz v0.1.0/go.mod h1:wXVsXxmyMQU6TN3zGRttjNn3h+iCAS7xQFC6TlNvLhk=
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
-github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -139,7 +133,6 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -153,8 +146,6 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5 h1:BvoENQQU+fZ9uukda/RzCAL/191HHwJA5b13R6diVlY=
-github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -220,7 +211,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -238,8 +228,6 @@ golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 h1:3MTrJm4PyNL9NBqvYDSj3DHl4
 golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.0.0-20200119044424-58c23975cae1 h1:5h3ngYt7+vXCDZCup/HkCQgW5XwmSvR/nA2JmJ0RErg=
-golang.org/x/image v0.0.0-20200119044424-58c23975cae1/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
Use `awalterschulze/gographviz` instead of `goccy/go-graphviz`

- Make this command's role just only printing `.dot` data