### PR TITLE
perf: Improve the performance of log.LTSVReader

### DIFF
--- a/internal/log/ltsv.go
+++ b/internal/log/ltsv.go
@@ -94,49 +94,45 @@ func (r *LTSVReader) Parse(entry *LogEntry) (*LogEntry, error) {
 	entry.Uid = ""
 	entry.SetNewUid = false
 
-	err := ltsv.DefaultParser.ParseLine(r.r.Bytes(), func(label []byte, value []byte) error {
-		l := string(label)
-		v := string(value)
-
-		switch l {
+	err := ltsv.DefaultParser.ParseLine(r.r.Bytes(), func(label, value []byte) error {
+		switch string(label) {
 		case "req":
-			entry.Req = v
-			method, uri := parseReq(v, r.matchingPatterns)
+			entry.Req = string(value)
+			method, uri := parseReq(string(value), r.matchingPatterns)
 			entry.Method = method
 			entry.Uri = uri
-			isIgnored := isIgnored(v, r.ignorePatterns)
-			entry.IsIgnored = isIgnored
+			entry.IsIgnored = isIgnored(string(value), r.ignorePatterns)
 
 		case "status":
-			status, err := strconv.Atoi(v)
+			status, err := strconv.Atoi(string(value))
 			if err != nil {
 				return err
 			}
 			entry.Status = status
 
 		case "time":
-			reqTime, err := time.Parse(r.timeFormat, v)
+			reqTime, err := time.Parse(r.timeFormat, string(value))
 			if err != nil {
 				return err
 			}
 			entry.Time = reqTime
 
 		case "uidset":
-			if v != "" && v != "-" {
-				if i := strings.Index(v, "="); i >= 0 {
-					entry.Uid = v[i+1:]
+			if string(value) != "" && string(value) != "-" {
+				if i := strings.Index(string(value), "="); i >= 0 {
+					entry.Uid = string(value)[i+1:]
 				} else {
-					entry.Uid = v
+					entry.Uid = string(value)
 				}
 				entry.SetNewUid = true
 			}
 
 		case "uidgot":
-			if v != "" && v != "-" {
-				if i := strings.Index(v, "="); i >= 0 {
-					entry.Uid = v[i+1:]
+			if string(value) != "" && string(value) != "-" {
+				if i := strings.Index(string(value), "="); i >= 0 {
+					entry.Uid = string(value)[i+1:]
 				} else {
-					entry.Uid = v
+					entry.Uid = string(value)
 				}
 			}
 		}

--- a/internal/log/ltsv.go
+++ b/internal/log/ltsv.go
@@ -79,8 +79,21 @@ func (r *LTSVReader) Read() bool {
 	return r.r.Scan()
 }
 
-func (r *LTSVReader) Parse() (*LogEntry, error) {
-	var entry LogEntry
+// Parse parses one line of log file into LogEntry struct
+// For reducing memory allocation, you can pass a LogEntry to record to reuse the given one.
+func (r *LTSVReader) Parse(entry *LogEntry) (*LogEntry, error) {
+	if entry == nil {
+		entry = &LogEntry{}
+	}
+	entry.Req = ""
+	entry.Method = ""
+	entry.Uri = ""
+	entry.IsIgnored = false
+	entry.Status = 0
+	entry.Time = time.Time{}
+	entry.Uid = ""
+	entry.SetNewUid = false
+
 	err := ltsv.DefaultParser.ParseLine(r.r.Bytes(), func(label []byte, value []byte) error {
 		l := string(label)
 		v := string(value)
@@ -132,7 +145,7 @@ func (r *LTSVReader) Parse() (*LogEntry, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &entry, nil
+	return entry, nil
 }
 
 func parseReq(req string, patterns []regexp.Regexp) (string, string) {

--- a/internal/log/ltsv.go
+++ b/internal/log/ltsv.go
@@ -101,7 +101,7 @@ func (r *LTSVReader) Parse(entry *LogEntry) (*LogEntry, error) {
 			method, uri := parseReq(string(value), r.matchingPatterns)
 			entry.Method = method
 			entry.Uri = uri
-			entry.IsIgnored = isIgnored(string(value), r.ignorePatterns)
+			entry.IsIgnored = isIgnored(uri, r.ignorePatterns)
 
 		case "status":
 			status, err := strconv.Atoi(string(value))
@@ -164,24 +164,13 @@ func parseReq(req string, patterns []regexp.Regexp) (string, string) {
 	}
 	for _, p := range patterns {
 		if p.MatchString(uri) {
-			uri = p.String()
-			return method, uri
+			return method, p.String()
 		}
 	}
 	return method, uri
 }
 
-func isIgnored(req string, ignorePatterns []regexp.Regexp) bool {
-	uri := req
-	i := strings.Index(req, " ")
-	if i >= 0 {
-		uri = req[i+1:]
-	}
-	i = strings.Index(req, "?")
-	if i >= 0 {
-		uri = uri[:i]
-	}
-
+func isIgnored(uri string, ignorePatterns []regexp.Regexp) bool {
 	for _, p := range ignorePatterns {
 		if p.MatchString(uri) {
 			return true

--- a/internal/log/ltsv.go
+++ b/internal/log/ltsv.go
@@ -136,10 +136,23 @@ func (r *LTSVReader) Parse() (*LogEntry, error) {
 }
 
 func parseReq(req string, patterns []regexp.Regexp) (string, string) {
-	splitted := strings.Split(req, " ")
-	method := splitted[0]
-	uri := strings.Split(splitted[1], "?")[0]
-
+	var method string
+	var uri string
+	i := strings.Index(req, " ")
+	if i >= 0 {
+		method = req[:i]
+		uri = req[i+1:]
+	} else {
+		return "", ""
+	}
+	i = strings.Index(uri, " ")
+	if i >= 0 {
+		uri = uri[:i]
+	}
+	i = strings.Index(uri, "?")
+	if i >= 0 {
+		uri = uri[:i]
+	}
 	for _, p := range patterns {
 		if p.MatchString(uri) {
 			uri = p.String()
@@ -150,8 +163,15 @@ func parseReq(req string, patterns []regexp.Regexp) (string, string) {
 }
 
 func isIgnored(req string, ignorePatterns []regexp.Regexp) bool {
-	splitted := strings.Split(req, " ")
-	uri := strings.Split(splitted[1], "?")[0]
+	uri := req
+	i := strings.Index(req, " ")
+	if i >= 0 {
+		uri = req[i+1:]
+	}
+	i = strings.Index(req, "?")
+	if i >= 0 {
+		uri = uri[:i]
+	}
 
 	for _, p := range ignorePatterns {
 		if p.MatchString(uri) {

--- a/internal/log/ltsv_test.go
+++ b/internal/log/ltsv_test.go
@@ -32,8 +32,9 @@ func BenchmarkLTSVReader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		f, _ := fs.Open(fileName)
 		logReader, _ := NewLTSVReader(f, LTSVReadOpt{MatchingGroups: matchingGroups})
+		var entry LogEntry
 		for logReader.Read() {
-			_, _ = logReader.Parse()
+			_, _ = logReader.Parse(&entry)
 		}
 		_ = f.Close()
 	}

--- a/internal/log/ltsv_test.go
+++ b/internal/log/ltsv_test.go
@@ -1,0 +1,40 @@
+package log
+
+import (
+	"github.com/spf13/afero"
+	"os"
+	"testing"
+)
+
+func BenchmarkLTSVReader(b *testing.B) {
+	fs := afero.NewOsFs()
+	dir, _ := os.Getwd()
+	fileName := dir + "/../../cmd/testdata/access.log"
+	matchingGroups := []string{
+		"^/$",
+		"^/initialize$",
+		"^/api/auth$",
+		"^/api/condition/[^/]+$",
+		"^/api/isu$",
+		"^/api/isu/[^/]+$",
+		"^/api/isu/[^/]+/graph$",
+		"^/api/isu/[^/]+/icon$",
+		"^/api/signout$",
+		"^/api/trend$",
+		"^/api/user/me$",
+		"^/isu/[^/]+$",
+		"^/isu/[^/]+/condition$",
+		"^/isu/[^/]+/graph$",
+		"^register$",
+		"/assets/*",
+	}
+
+	for i := 0; i < b.N; i++ {
+		f, _ := fs.Open(fileName)
+		logReader, _ := NewLTSVReader(f, LTSVReadOpt{MatchingGroups: matchingGroups})
+		for logReader.Read() {
+			_, _ = logReader.Parse()
+		}
+		_ = f.Close()
+	}
+}

--- a/internal/scenario.go
+++ b/internal/scenario.go
@@ -40,8 +40,9 @@ func (p *ScenarioProfiler) Profile(reader *log.LTSVReader) ([]ScenarioStruct, er
 
 	i := 0
 	var startTime time.Time
+	var entry log.LogEntry
 	for reader.Read() {
-		entry, err := reader.Parse()
+		_, err := reader.Parse(&entry)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/transition.go
+++ b/internal/transition.go
@@ -20,8 +20,9 @@ func (p *TransitionProfiler) Profile(reader *log.LTSVReader) (*Transition, error
 	endpoints := map[string]struct{}{}
 	endpoints[""] = struct{}{}
 
+	var entry log.LogEntry
 	for reader.Read() {
-		entry, err := reader.Parse()
+		_, err := reader.Parse(&entry)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/trend.go
+++ b/internal/trend.go
@@ -20,8 +20,9 @@ func (p *TrendProfiler) Profile(reader *log.LTSVReader, interval int) (*Trend, e
 	var startTime time.Time
 	step := 0
 
+	var entry log.LogEntry
 	for reader.Read() {
-		entry, err := reader.Parse()
+		_, err := reader.Parse(&entry)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
benchmark result

```
goos: darwin
goarch: arm64
pkg: github.com/haijima/stool/internal/log
              │     Old     │                 New                 │
              │   sec/op    │   sec/op     vs base                │
LTSVReader-10   523.2m ± 1%   251.8m ± 1%  -51.87% (p=0.000 n=10)

              │      Old      │                 New                  │
              │     B/op      │     B/op      vs base                │
LTSVReader-10   450.28Mi ± 0%   88.96Mi ± 0%  -80.24% (p=0.000 n=10)

              │     Old     │                 New                 │
              │  allocs/op  │  allocs/op   vs base                │
LTSVReader-10   6.450M ± 0%   1.291M ± 0%  -79.98% (p=0.000 n=10)
```